### PR TITLE
Update `tsequenceset_make_gaps` function

### DIFF
--- a/builder/build_pymeos_functions.py
+++ b/builder/build_pymeos_functions.py
@@ -89,6 +89,7 @@ function_modifiers = {
     "floatset_make": array_parameter_modifier("values", "count"),
     "textset_make": textset_make_modifier,
     "geoset_make": array_length_remover_modifier("values", "count"),
+    "tsequenceset_make_gaps": array_length_remover_modifier("instants", "count"),
 }
 
 # List of result function parameters in tuples of (function, parameter)
@@ -185,6 +186,7 @@ nullable_parameters = {
     ("tpoint_minus_geom_time", "zspan"),
     ("tpoint_minus_geom_time", "period"),
     ("stbox_make", "s"),
+    ("tsequenceset_make_gaps", "maxt"),
 }
 
 

--- a/builder/build_pymeos_functions_modifiers.py
+++ b/builder/build_pymeos_functions_modifiers.py
@@ -42,7 +42,6 @@ def textset_make_modifier(function: str) -> str:
 
 def meos_initialize_modifier(_: str) -> str:
     return """def meos_initialize(tz_str: "Optional[str]") -> None:
-    
     if "PROJ_DATA" not in os.environ and "PROJ_LIB" not in os.environ:
         proj_dir = os.path.join(os.path.dirname(__file__), "proj_data")
         if os.path.exists(proj_dir):

--- a/builder/meos.h
+++ b/builder/meos.h
@@ -428,7 +428,6 @@ typedef enum
   INTERSECTS =     0,
   CONTAINS =       1,
   TOUCHES =        2,
-  COVERS =         3,
 } spatialRel;
 
 typedef struct
@@ -545,9 +544,9 @@ extern int meos_errno_reset(void);
 
 typedef void (*error_handler_fn)(int, int, char *);
 
-/* extern void meos_initialize_timezone(const char *name);  (undefined) */
+extern void meos_initialize_timezone(const char *name);
 extern void meos_initialize_error_handler(error_handler_fn err_handler);
-/* extern void meos_finalize_timezone(void);  (undefined) */
+extern void meos_finalize_timezone(void);
 
 extern bool meos_set_datestyle(char *newval, void *extra);
 extern bool meos_set_intervalstyle(char *newval, int extra);

--- a/pymeos_cffi/functions.py
+++ b/pymeos_cffi/functions.py
@@ -205,7 +205,6 @@ def meos_get_intervalstyle() -> str:
 
 
 def meos_initialize(tz_str: "Optional[str]") -> None:
-
     if "PROJ_DATA" not in os.environ and "PROJ_LIB" not in os.environ:
         proj_dir = os.path.join(os.path.dirname(__file__), "proj_data")
         if os.path.exists(proj_dir):
@@ -6964,16 +6963,15 @@ def tsequenceset_make(
 
 def tsequenceset_make_gaps(
     instants: "const TInstant **",
-    count: int,
     interp: "interpType",
-    maxt: "Interval *",
+    maxt: "Optional['Interval *']",
     maxdist: float,
 ) -> "TSequenceSet *":
     instants_converted = [_ffi.cast("const TInstant *", x) for x in instants]
     interp_converted = _ffi.cast("interpType", interp)
-    maxt_converted = _ffi.cast("Interval *", maxt)
+    maxt_converted = _ffi.cast("Interval *", maxt) if maxt is not None else _ffi.NULL
     result = _lib.tsequenceset_make_gaps(
-        instants_converted, count, interp_converted, maxt_converted, maxdist
+        instants_converted, len(instants), interp_converted, maxt_converted, maxdist
     )
     _check_error()
     return result if result != _ffi.NULL else None


### PR DESCRIPTION
Addresses MobilityDB/PyMEOS#50.
Add modifier for `tsequenceset_make_gaps` to make `maxt` optional.
Removes `count` parameter from `tsequenceset_make_gaps` (uses length of instant list).