### PR TITLE
Update workflow and disable builds for Mac13

### DIFF
--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -137,7 +137,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+#        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
         include:
           - ld_prefix: "/usr/local"
           - os: macos-14
@@ -213,7 +214,6 @@ jobs:
           # Disable PyPy builds
           # Disable builds on musllinux
           # Disable builds in linux architectures other than x86_64
-          CIBW_BUILD: "cp38*"
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA C_INCLUDE_PATH
@@ -252,9 +252,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        python-version: [ "3.8" ]
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+#        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
 
     steps:
       - name: Checkout
@@ -273,18 +273,10 @@ jobs:
           cache: "pip"
 
       - name: Install PyMEOS-CFFI wheels
-        if: matrix.os != 'macos-13'
         run: |
           python -m pip install --upgrade pip
           ls -l ./pymeos_cffi_wheels
           pip install -v -f ./pymeos_cffi_wheels pymeos_cffi==${{ needs.checks.outputs.version }}
-
-      - name: Install PyMEOS-CFFI wheels
-        if: matrix.os == 'macos-13'
-        run: |
-          python -m pip install --upgrade pip
-          ls -l ./pymeos_cffi_wheels
-          pip install -v ./pymeos_cffi_wheels/pymeos_cffi-1.1.2.post1-cp38-cp38-macosx_13_6_x86_64.whl
 
       - name: Run PyMEOS-CFFI check
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -1,7 +1,7 @@
 name: Build PyMEOS CFFI
 
 on:
-  create:
+  push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -242,7 +242,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ ubuntu-latest, macos-13, macos-14 ]
 
     steps:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -176,6 +176,7 @@ jobs:
           git clone --depth 1 --branch ${{ needs.checks.outputs.branch }} https://github.com/MobilityDB/MobilityDB
           mkdir MobilityDB/build
           cd MobilityDB/build
+          export MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 13.6 }}"
           cmake .. -DMEOS=on
           make -j
           sudo make install

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -212,6 +212,7 @@ jobs:
           # Disable PyPy builds
           # Disable builds on musllinux
           # Disable builds in linux architectures other than x86_64
+          CIBW_BUILD: "cp38*"
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA C_INCLUDE_PATH
@@ -250,7 +251,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+#        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.8" ]
         os: [ ubuntu-latest, macos-13, macos-14 ]
 
     steps:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -273,10 +273,18 @@ jobs:
           cache: "pip"
 
       - name: Install PyMEOS-CFFI wheels
+        if: matrix.os != 'macos-13'
         run: |
           python -m pip install --upgrade pip
           ls -l ./pymeos_cffi_wheels
           pip install -v -f ./pymeos_cffi_wheels pymeos_cffi==${{ needs.checks.outputs.version }}
+
+      - name: Install PyMEOS-CFFI wheels
+        if: matrix.os == 'macos-13'
+        run: |
+          python -m pip install --upgrade pip
+          ls -l ./pymeos_cffi_wheels
+          pip install -v ./pymeos_cffi_wheels/pymeos_cffi-1.1.2.post1-cp38-cp38-macosx_13_6_x86_64.whl
 
       - name: Run PyMEOS-CFFI check
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Install PyMEOS-CFFI wheels
         run: |
           python -m pip install --upgrade pip
-          pip install -f ./pymeos_cffi_wheels pymeos_cffi
+          pip install -f ./pymeos_cffi_wheels --no-index pymeos_cffi
 
       - name: Run PyMEOS-CFFI check
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -208,7 +208,7 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA C_INCLUDE_PATH
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 11 }}"
+            MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 13 }}"
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &&
             yum -y update &&

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -262,7 +262,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ls -l ./pymeos_cffi_wheels
-          pip install -f ./pymeos_cffi_wheels --no-index pymeos_cffi
+          pip install -v -f ./pymeos_cffi_wheels pymeos_cffi
 
       - name: Run PyMEOS-CFFI check
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -208,7 +208,7 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA C_INCLUDE_PATH
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 13 }}"
+            MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 13.6 }}"
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &&
             yum -y update &&

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -246,9 +246,6 @@ jobs:
         os: [ ubuntu-latest, macos-13, macos-14 ]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -92,6 +92,13 @@ jobs:
           echo "branch=$branch" >> $GITHUB_OUTPUT
           echo "Branch is $branch."
 
+      - name: Check version
+        id: check_version
+        run: |
+          version=${GITHUB_REF#refs/tags/v}
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Version is $version."
+
 
   build_sdist:
     name: Build PyMEOS CFFI source distribution
@@ -237,7 +244,7 @@ jobs:
 
   test_wheels:
     name: Test PyMEOS CFFI wheel - Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    needs: build_wheels
+    needs: [ checks, build_wheels ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -265,7 +272,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ls -l ./pymeos_cffi_wheels
-          pip install -v -f ./pymeos_cffi_wheels pymeos_cffi
+          pip install -v -f ./pymeos_cffi_wheels pymeos_cffi==${{ needs.checks.outputs.version }}
 
       - name: Run PyMEOS-CFFI check
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -139,6 +139,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get dependencies from homebrew (cache)
+        uses: tecolicom/actions-use-homebrew-tools@v1
+        if: runner.os == 'macOS'
+        with:
+          tools: cmake libpq proj json-c gsl geos
+
       - name: Update brew
         if: matrix.os == 'macos-13'
         # Necessary to avoid issue with macOS runners. See
@@ -147,12 +153,6 @@ jobs:
           brew reinstall python@3.12 || brew link --overwrite python@3.12
           brew reinstall python@3.11 || brew link --overwrite python@3.11
           brew update
-
-      - name: Get dependencies from homebrew (cache)
-        uses: tecolicom/actions-use-homebrew-tools@v1
-        if: runner.os == 'macOS'
-        with:
-          tools: cmake libpq proj json-c gsl geos
 
       - name: Get PROJ version
         id: proj_version

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -208,7 +208,7 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA C_INCLUDE_PATH
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=14.0
+            MACOSX_DEPLOYMENT_TARGET="${{ matrix.os == 'macos-14' && 14 || 11 }}"
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &&
             yum -y update &&

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -16,6 +16,7 @@ jobs:
       is_rc: ${{ steps.check_rc.outputs.is_rc }}
       is_prerelease: ${{ steps.check_prerelease.outputs.is_prerelease }}
       branch: ${{ steps.check_branch.outputs.branch }}
+      version: ${{ steps.check_version.outputs.version }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -275,7 +275,6 @@ jobs:
       - name: Install PyMEOS-CFFI wheels
         run: |
           python -m pip install --upgrade pip
-          ls -l ./pymeos_cffi_wheels
           pip install -v -f ./pymeos_cffi_wheels pymeos_cffi==${{ needs.checks.outputs.version }}
 
       - name: Run PyMEOS-CFFI check

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -264,6 +264,7 @@ jobs:
       - name: Install PyMEOS-CFFI wheels
         run: |
           python -m pip install --upgrade pip
+          ls -l ./pymeos_cffi_wheels
           pip install -f ./pymeos_cffi_wheels --no-index pymeos_cffi
 
       - name: Run PyMEOS-CFFI check

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -187,7 +187,7 @@ jobs:
           cache: "pip"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.20.0
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Set PROJ_DATA (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -246,6 +246,9 @@ jobs:
         os: [ ubuntu-latest, macos-13, macos-14 ]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:

--- a/builder/templates/init.py
+++ b/builder/templates/init.py
@@ -2,7 +2,7 @@ from .functions import *
 from .enums import *
 from .errors import *
 
-__version__ = "1.1.2-post.1"
+__version__ = "1.1.3"
 __all__ = [
     # Exceptions
     "MeosException",

--- a/builder/templates/init.py
+++ b/builder/templates/init.py
@@ -2,7 +2,7 @@ from .functions import *
 from .enums import *
 from .errors import *
 
-__version__ = "1.1.2"
+__version__ = "1.1.2-post.1"
 __all__ = [
     # Exceptions
     "MeosException",

--- a/pymeos_cffi/__init__.py
+++ b/pymeos_cffi/__init__.py
@@ -2,7 +2,7 @@ from .functions import *
 from .enums import *
 from .errors import *
 
-__version__ = "1.1.2-post.1"
+__version__ = "1.1.3"
 __all__ = [
     # Exceptions
     "MeosException",

--- a/pymeos_cffi/__init__.py
+++ b/pymeos_cffi/__init__.py
@@ -2,7 +2,7 @@ from .functions import *
 from .enums import *
 from .errors import *
 
-__version__ = "1.1.2"
+__version__ = "1.1.2-post.1"
 __all__ = [
     # Exceptions
     "MeosException",


### PR DESCRIPTION
Changes:

- Disable builds for MacOS 13 (until #6 is fixed)
- Add build for Python 3.13
- Update `cibuildwheel`
- Change trigger event
